### PR TITLE
Initialize Harmony cross-chain universal identity Token

### DIFF
--- a/contracts/IToken721.sol
+++ b/contracts/IToken721.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
+
+interface IToken721 is IERC721Metadata, IERC721Enumerable {
+    function updateOwnership(address[] memory owners, uint[] memory tokenIds) external;
+}

--- a/contracts/OwnershipValidator.sol
+++ b/contracts/OwnershipValidator.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "./Token721.sol";
+
+contract OwnershipValidator is Ownable {
+
+    // eth ERC721 address => harmony Token721 address
+    mapping(string => address) public _addrMap;
+
+    function register(string memory ethAddress, Token721 oneAddress) public onlyOwner {
+        require(Token721(address(0)) != oneAddress, "Invalid address");
+        _addrMap[ethAddress] = address(oneAddress);
+    }
+
+    function unregister(string memory ethAddress) public onlyOwner {
+        require(address(0) != address(_addrMap[ethAddress]), "the eth address has not been registered");
+        delete _addrMap[ethAddress];
+    }
+
+    function updateOwnership(string memory ethAddress, address[] memory owners, uint[] memory tokenIds)
+    external virtual onlyOwner {
+        require(address(0) != address(_addrMap[ethAddress]), "the eth address has not been registered");
+        return Token721(address(_addrMap[ethAddress])).updateOwnership(owners, tokenIds);
+    }
+
+    function balanceOf(string memory ethAddress, address owner) public view  returns (uint256) {
+        require(address(0) != address(_addrMap[ethAddress]), "the eth address has not been registered");
+        return Token721(address(_addrMap[ethAddress])).balanceOf(owner);
+    }
+
+    function ownerOf(string memory ethAddress, uint256 tokenId) public view returns (address) {
+        require(address(0) != address(_addrMap[ethAddress]), "the eth address has not been registered");
+        return Token721(address(_addrMap[ethAddress])).ownerOf(tokenId);
+    }
+
+    function name(string memory ethAddress) public view  returns (string memory) {
+        require(address(0) != address(_addrMap[ethAddress]), "the eth address has not been registered");
+        return Token721(address(_addrMap[ethAddress])).name();
+    }
+
+    function symbol(string memory ethAddress) public view returns (string memory) {
+        require(address(0) != address(_addrMap[ethAddress]), "the eth address has not been registered");
+        return Token721(address(_addrMap[ethAddress])).symbol();
+    }
+
+    function tokenURI(string memory ethAddress, uint256 tokenId) public view returns (string memory) {
+        require(address(0) != address(_addrMap[ethAddress]), "the eth address has not been registered");
+        return Token721(address(_addrMap[ethAddress])).tokenURI(tokenId);
+    }
+}

--- a/contracts/OwnershipValidator.sol
+++ b/contracts/OwnershipValidator.sol
@@ -19,6 +19,12 @@ contract OwnershipValidator is Ownable {
         delete _addrMap[ethAddress];
     }
 
+    function initialize(string memory ethAddress, address[] memory owners, uint[] memory tokenIds)
+    external virtual onlyOwner {
+        require(address(0) != address(_addrMap[ethAddress]), "the eth address has not been registered");
+        return Token721(address(_addrMap[ethAddress])).initialize(owners, tokenIds);
+    }
+
     function updateOwnership(string memory ethAddress, address[] memory owners, uint[] memory tokenIds)
     external virtual onlyOwner {
         require(address(0) != address(_addrMap[ethAddress]), "the eth address has not been registered");

--- a/contracts/Token721.sol
+++ b/contracts/Token721.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import "./IToken721.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+
+contract Token721 is ERC721, ERC721Enumerable, IToken721, Ownable, Initializable {
+
+    constructor(string memory name_, string memory symbol_) ERC721(name_, symbol_) {}
+
+    function initialize(address[] memory owners, uint[] memory tokenIds) public initializer {
+        require(owners.length != 0, "owners must be provided");
+        require(owners.length == tokenIds.length, "data doesn't match");
+        for (uint i = 0; i < owners.length; i++) {
+            _mint(owners[i], tokenIds[i]);
+        }
+    }
+
+    function updateOwnership(address[] memory owners, uint[] memory tokenIds) external virtual override onlyOwner {
+        require(owners.length != 0, "owners must be provided");
+        require(owners.length == tokenIds.length, "data doesn't match");
+        for (uint i = 0; i < owners.length; i++) {
+            require(_exists(tokenIds[i]), "tokenId doesn't exist");
+            _transfer(ownerOf(tokenIds[i]), owners[i], tokenIds[i]);
+        }
+    }
+
+    function approve(address to, uint256 tokenId) public virtual override(IERC721, ERC721) {
+        revert('Unsupported operation');
+    }
+
+    function getApproved(uint256 tokenId) public view virtual override(IERC721, ERC721) returns (address) {
+        revert('Unsupported operation');
+    }
+
+    function setApprovalForAll(address operator, bool approved) public virtual override(IERC721, ERC721) {
+        revert('Unsupported operation');
+    }
+
+    function isApprovedForAll(address owner, address operator) public view virtual override(IERC721, ERC721) returns (bool) {
+        revert('Unsupported operation');
+    }
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public virtual override(IERC721, ERC721) {
+        revert('Unsupported operation');
+    }
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public virtual override(IERC721, ERC721) {
+        revert('Unsupported operation');
+    }
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory _data
+    ) public virtual override(IERC721, ERC721) {
+        revert('Unsupported operation');
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view virtual
+    override(IERC165, ERC721, ERC721Enumerable) returns (bool) {
+        return interfaceId == type(IToken721).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override(ERC721, ERC721Enumerable) {
+        super._beforeTokenTransfer(from, to, tokenId);
+    }
+}


### PR DESCRIPTION
Initialize the cross-chain universal identity Token

IToken721 - define the interface of identity token which identify the ownership of ERC721 tokens on the Ethereum chain

Token721 - implementing the IToken721 and ensuring only the contract owner can update the state(ownerships of tokens) in the contract, others (like dApp) can only read-only from the contract

OwnershipValidator - The unified access endpoints of all Token721 in order to facilitate the backend sync process to update each Token721 instance.

